### PR TITLE
The net.minidev.json-smart version was updated from 2.4.8 to 2.4.10, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<swagger-parser.version>2.1.2</swagger-parser.version>
 		<openapi-generator.version>6.2.1</openapi-generator.version>
 		<javax-ws-version>2.1.1</javax-ws-version>
-		<json-smart.version>2.4.8</json-smart.version>
+		<json-smart.version>2.4.10</json-smart.version>
 		<surefire.version>3.0.0-M7</surefire.version>
 		<sonar.organization>mastercard</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
The net.minidev.json-smart version was updated from 2.4.8 to 2.4.10, to avoid the vulnerability 'CVE-2023-1370'